### PR TITLE
Tweak colors and dot greying out scenarios 

### DIFF
--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -35,12 +35,15 @@ public:
                 ped = dynamic_cast<CPed*>(taskSimpleAimGun->GetAt(0, 1));
 
             if (dotSprite.m_pTexture.ptr) {
-                rage::Color32 col = { 255, 255, 255, 255 };
+                rage::Color32 col = { 
+                    (uint8_t)255, (uint8_t)255, (uint8_t)255,
+                    CHud::Components[aHudComponentInfo[HUD_WEAPON_DOT].m_nIndex]->alpha // The game already automatically greys out the dot in specific instances.
+                };
                 if (ped) {
                     if (CPed::IsPedDead(ped))
-                        col = CHudColours::Get(HUD_COLOUR_GREY, 255);
+                        col = { 255, 255, 255, 60 }; // Default greyed out dot color.
                     else
-                        col = CHudColours::Get(HUD_COLOUR_REDDARK, 255);
+                        col = CHudColours::Get(HUD_COLOUR_RED);
                 }
 
                 dotSprite.SetRenderState();


### PR DESCRIPTION
The game already greys out the default dot in specific scenarios (when aiming at walls that are too close for example). It does this by simply modifying the alpha value of the dot, so I have changed the code to read the default dot's current alpha value and then use it for the new one.

Since we now know that the greyed out dot is simply just an alpha tweak, I've also replaced the "HUD_COLOUR_GREY" color with white with an alpha of 60 which is the original greyed out color.

A bit more of a subjective change, but I've also changed the red dot from being dark red to red since it's normal red in RDR2 and GTA V afaik.